### PR TITLE
drm/hisilicon: Fixed pcie resource conflict between drm and firmware

### DIFF
--- a/drivers/gpu/drm/hisilicon/hibmc/hibmc_drm_drv.c
+++ b/drivers/gpu/drm/hisilicon/hibmc/hibmc_drm_drv.c
@@ -331,6 +331,11 @@ static int hibmc_pci_probe(struct pci_dev *pdev,
 	struct drm_device *dev;
 	int ret;
 
+	ret = drm_fb_helper_remove_conflicting_pci_framebuffers(pdev,
+								"hibmcdrmfb");
+	if (ret)
+		return ret;
+
 	dev = drm_dev_alloc(&hibmc_driver, &pdev->dev);
 	if (IS_ERR(dev)) {
 		DRM_ERROR("failed to allocate drm_device\n");


### PR DESCRIPTION
upstream commit: c3480301d750bd58bab35994ecf015a4682a17dd

use the drm_fb_helper_remove_conflicting_pci_framebuffer to remove
the framebuffer initialized by fireware/bootloader to avoid resource
conflict.

Signed-off-by: Tian Tao <tiantao6@hisilicon.com>
Acked-by: Thomas Zimmermann <tzimmermann@suse.de>
Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>
Link: https://patchwork.freedesktop.org/patch/msgid/1582524112-5628-1-git-send-email-tiantao6@hisilicon.com