### PR TITLE
drm/hisilicon: Fixed missing parameter

### DIFF
--- a/drivers/gpu/drm/hisilicon/hibmc/hibmc_drm_drv.c
+++ b/drivers/gpu/drm/hisilicon/hibmc/hibmc_drm_drv.c
@@ -331,7 +331,7 @@ static int hibmc_pci_probe(struct pci_dev *pdev,
 	struct drm_device *dev;
 	int ret;
 
-	ret = drm_fb_helper_remove_conflicting_pci_framebuffers(pdev,
+	ret = drm_fb_helper_remove_conflicting_pci_framebuffers(pdev, 0,
 								"hibmcdrmfb");
 	if (ret)
 		return ret;


### PR DESCRIPTION
fix commit: drm/hisilicon: Fixed pcie resource conflict between drm and firmware

Signed-off-by: katrinzhou <katrinzhou@tencent.com>