### PR TITLE
Dist update

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -118,6 +118,13 @@ else
 RPMCROSSFLAGS = --without crossbuild
 endif
 
+# For re-distribute to another distro
+ifneq ($(DISTRO),)
+override RPMFLAGS := --define "dist .$(DISTRO)" $(RPMFLAGS)
+$(info "NOTE: DISTRO is set, building for another distro $(DISTRO)")
+$(info "      You shoudn't do this unless you know what you are doing.")
+endif
+
 # Always make sure workdir exists
 $(shell mkdir -p $(WORKDIRS))
 

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -28,8 +28,8 @@ NATIVE_ARCH := $(shell uname -m | sed -e 's/amd64/x86_64/;s/arm64/aarch64/;s/*86
 ###### Build parameters, change them with `make <PARAM>=<VALUE>` ######
 # When building binary package, which arch to build against
 ARCH := $(NATIVE_ARCH)
-# When building SRPM, which ARCH to be covered
-SPEC_ARCH := x86_64 aarch64
+# ARCH to be covered by spec file
+SPEC_ARCH := x86_64 aarch64 riscv64
 # Kernel variant, will be appended to kernel release string as suffix
 # to indicate this is a variant kernel (eg. debug; minimal;)
 VARIANT :=

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -88,20 +88,21 @@ RPM_SRCRPMDIR := $(RPM_TOPDIR)/SRPMS
 RPM_BUILDROOTDIR := $(RPM_TOPDIR)/BUILDROOT
 
 ### RPM build options
+# All params enabled by default (except kABI check, see below), DEFAULT_ENABLED overrides DEFAULT_DISABLE.
+DEFAULT_DISABLED=
+DEFAULT_ENABLED=
+
+## A few shortcut for commonly used params:
 # Disable KABI check by default
 KABI=0
 ifeq ($(KABI), 0)
-override RPMFLAGS := --without kabichk $(RPMFLAGS)
-else
-override RPMFLAGS := --with kabichk $(RPMFLAGS)
+override DEFAULT_DISABLED := kabichk $(DEFAULT_DISABLED)
 endif
 
 # Enabled module sign by default
 MODSIGN=1
 ifeq ($(MODSIGN), 0)
-override RPMFLAGS := --without modsign $(RPMFLAGS)
-else
-override RPMFLAGS := --with modsign $(RPMFLAGS)
+override DEFAULT_DISABLED := modsign $(DEFAULT_DISABLED)
 endif
 
 # Allow to skip RPM dependency check
@@ -154,7 +155,10 @@ $(SPECFILE): always-rebuild
 		--build-arch "$(SRPM_ARCH)" \
 		--kernel-config "$(CONFIG)" \
 		--kernel-variant "$(VARIANT)" \
+		--set-default-disabled "$(DEFAULT_DISABLED)" \
+		--set-default-enabled "$(DEFAULT_ENABLED)" \
 		> $(SPECFILE)
+	@grep -A2 "# == Package options ==" $(SPECFILE) | cut -c3-
 
 dist-specfile: $(SPECFILE) $(TOPDIR)/.config
 	@echo "$(SPECFILE)"

--- a/dist/scripts/gen-spec.sh
+++ b/dist/scripts/gen-spec.sh
@@ -222,7 +222,7 @@ gen_spec() {
 				_spec+="$(_gen_kerver_spec)"
 				;;
 			"{{ARCHSOURCESPEC}}"* )
-				_spec+="$(_gen_config_source)"
+				_spec+="$(_gen_arch_source)"
 				;;
 			"{{CONFBUILDSPEC}}"* )
 				_spec+="$(_gen_config_build)"

--- a/dist/scripts/gen-spec.sh
+++ b/dist/scripts/gen-spec.sh
@@ -36,11 +36,15 @@ while [[ $# -gt 0 ]]; do
 			shift 2
 			;;
 		--set-default-disabled )
-			DEFAULT_DISALBED=" $2 $DEFAULT_DISALBED"
+			for param in $2; do
+				DEFAULT_DISALBED=" $param $DEFAULT_DISALBED"
+			done
 			shift 2
 			;;
 		--set-default-enabled )
-			DEFAULT_DISALBED="${DEFAULT_DISALBED/ $2 /}"
+			for param in $2; do
+				DEFAULT_DISALBED="${DEFAULT_DISALBED/ $param /}"
+			done
 			shift 2
 			;;
 		* )

--- a/dist/scripts/lib-config.sh
+++ b/dist/scripts/lib-config.sh
@@ -9,7 +9,8 @@
 . "$(dirname "$(realpath "$0")")/lib.sh"
 
 CONFIG_PATH=${CONFIG_PATH:-$DISTDIR/configs}
-CONFIG_ARCH=( x86_64 aarch64 )
+# shellcheck disable=SC2206
+CONFIG_ARCH=( $SPEC_ARCH )
 CONFIG_SPECS=( "$CONFIG_PATH"/[0-9][0-9]* )
 CONFIG_OUTDIR=$SOURCEDIR
 CONFIG_CACHE=$DISTDIR/workdir/config_cache

--- a/dist/scripts/lib-config.sh
+++ b/dist/scripts/lib-config.sh
@@ -73,8 +73,10 @@ get_all_depends() {
 	while read -r _dep; do
 		if ! [[ "$_dep" ]]; then
 			continue
+		elif [[ "$_dep" =~ y|n|m ]]; then
+			_deps+=( "$_dep" )
 		elif [[ "$_dep" =~ [a-zA-Z0-9] ]]; then
-			_deps+=( "$_dep=$(get_config_val "$_dep" "$2")" )
+			_deps+=( "$_dep[=$(get_config_val "$_dep" "$2")]" )
 		else
 			_deps+=( "$_dep" )
 		fi
@@ -83,6 +85,7 @@ get_all_depends() {
 		-e 's/([^\)])$/\1)/' \
 		-e '2,$s/^/\&\&/' \
 		-e 's/(\|\||&&|=|!=|<|<=|>|>=|!|\(|\)|([[:alnum:]_-]+))/\n\1\n/g')"
+	# The regex above simply tokenize the Kconfig expression
 
 	echo "${_deps[@]}"
 

--- a/dist/scripts/lib.sh
+++ b/dist/scripts/lib.sh
@@ -73,6 +73,7 @@ get_dist_makefile_var() {
 [ "$DISTPATH" ] || DISTPATH=$(get_dist_makefile_var DISTPATH)
 [ "$DISTDIR" ] || DISTDIR=$TOPDIR/$DISTPATH
 [ "$SOURCEDIR" ] || SOURCEDIR=$DISTDIR/rpm/SOURCES
+[ "$SPEC_ARCH" ] || VENDOR=$(get_dist_makefile_var SPEC_ARCH)
 
 if ! [ -s "$TOPDIR/Makefile" ]; then
 	echo "Dist tools can only be run within a valid Linux Kernel git workspace." >&2
@@ -97,6 +98,9 @@ get_native_arch () {
 # with different name due to historical reasons.
 get_kernel_arch () {
 	case $1 in
+		riscv64 )
+			echo "riscv"
+			;;
 		arm64 | aarch64 )
 			echo "arm64"
 			;;
@@ -115,6 +119,9 @@ get_kernel_arch () {
 # source code base sub path in arch/
 get_kernel_src_arch () {
 	case $1 in
+		riscv64 )
+			echo "riscv"
+			;;
 		arm64 | aarch64 )
 			echo "arm64"
 			;;

--- a/dist/scripts/lib.sh
+++ b/dist/scripts/lib.sh
@@ -55,7 +55,7 @@ get_dist_makefile_var() {
 	# Match anyline start with "^$1\s*=\s*", strip and remove matching part then store in hold buffer.
 	# Pprint the hold buffer on exit. This ensure the last assigned value is used, matches Makefile syntax well
 	_val=$(sed -nE -e \
-		"/^$1\s*=\s*(.*)/{s/^\s*^$1\s*=\s*//;h};\${x;p}" \
+		"/^$1\s*:?=\s*(.*)/{s/^\s*^$1\s*:?=\s*//;h};\${x;p}" \
 		"$(dirname "$(realpath "$_lib_source")")/../Makefile")
 
 	case $_val in
@@ -73,7 +73,7 @@ get_dist_makefile_var() {
 [ "$DISTPATH" ] || DISTPATH=$(get_dist_makefile_var DISTPATH)
 [ "$DISTDIR" ] || DISTDIR=$TOPDIR/$DISTPATH
 [ "$SOURCEDIR" ] || SOURCEDIR=$DISTDIR/rpm/SOURCES
-[ "$SPEC_ARCH" ] || VENDOR=$(get_dist_makefile_var SPEC_ARCH)
+[ "$SPEC_ARCH" ] || SPEC_ARCH=$(get_dist_makefile_var SPEC_ARCH)
 
 if ! [ -s "$TOPDIR/Makefile" ]; then
 	echo "Dist tools can only be run within a valid Linux Kernel git workspace." >&2

--- a/dist/sources/filter-modules.sh
+++ b/dist/sources/filter-modules.sh
@@ -25,7 +25,7 @@ netdrvs="appletalk can dsa hamradio ieee802154 irda ppp slip usb wireless"
 
 ethdrvs="3com adaptec alteon amd aquantia arc atheros broadcom cadence calxeda chelsio cisco dec dlink emulex icplus marvell mellanox micrel myricom neterion nvidia oki-semi packetengines qlogic rdc renesas sfc silan sis smsc stmicro sun tehuti ti wiznet xircom"
 
-inputdrvs="gameport tablet touchscreen"
+inputdrvs="gameport tablet touchscreen joystick"
 
 hiddrvs="surface-hid"
 

--- a/dist/sources/filter-riscv64.sh
+++ b/dist/sources/filter-riscv64.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+# Copied from Fedora
+
+# This is the x86_64 override file for the core/drivers package split.  The
+# module directories listed here and in the generic list in filter-modules.sh
+# will be moved to the resulting kernel-modules package for this arch.
+# Anything not listed in those files will be in the kernel-core package.
+#
+# Please review the default list in filter-modules.sh before making
+# modifications to the overrides below.  If something should be removed across
+# all arches, remove it in the default instead of per-arch.
+
+# Defaults work so no need to override

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -25,35 +25,26 @@
 # upstream
 %global _lto_cflags %{nil}
 
-###### Kernel packaging params #################################################
+###### Kernel packaging options #################################################
 # Since we need to generate kernel, kernel-subpackages, perf, bpftools, from
 # this one single code tree, following build switches are very helpful.
 #
-# The following build options are enabled by default, but may become disabled
-# by later checks. These can also be disabled by using
-# --without <opt> in the rpmbuild command, or by forcing these values to 0.
+# The following build options can be enabled or disabled with --with/--without
+# in the rpmbuild command. But may by disabled by later checks#
 #
-# kernel-core
-%define with_core	%{?_without_up: 0}		%{?!_without_up: 1}
-# kernel-doc
-%define with_doc	%{?_without_doc: 0}		%{?!_without_doc: 1}
-# kernel-headers
-%define with_headers	%{?_without_headers: 0}		%{?!_without_headers: 1}
-# perf
-%define with_perf	%{?_without_perf: 0}		%{?!_without_perf: 1}
-# tools
-%define with_tools	%{?_without_tools: 0}		%{?!_without_tools: 1}
-# bpf tool
-%define with_bpftool	%{?_without_bpftool: 0}		%{?!_without_bpftool: 1}
-# kernel-debuginfo
-%define with_debuginfo	%{?_without_debuginfo: 0}	%{?!_without_debuginfo: 1}
-# internal samples and selftests
-%define with_selftests	%{?_without_selftests: 0}	%{?!_without_selftests: 1}
-# Control whether we perform a compat. check against published ABI.
-%define with_modsign	%{?_without_modsign: 0}		%{?!_without_modsign: 1}
-# Control whether we perform a compat. check against published ABI.
-%define with_kabichk	%{?_with_kabichk: 1}		%{?!_with_kabichk: 0}
-# Cross compile requested?
+# This section defines following options:
+# with_core: kernel core pkg
+# with_doc: kernel doc pkg
+# with_headers: kernel headers pkg
+# with_perf: perf tools pkg
+# with_tools: kernel tools pkg
+# with_bpftool: bpftool pkg
+# with_debuginfo: debuginfo for all packages
+# with_modsign: if mod should be signed
+# with_kabichk: if kabi check is needed at the end of build
+{{PKGPARAMSPEC}}
+
+# Only use with cross build, don't touch it unless you know what you are doing
 %define with_crossbuild	%{?_with_crossbuild: 1}		%{?!_with_crossbuild: 0}
 
 ###### Kernel signing params #################################################

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -1089,7 +1089,7 @@ fi
 /boot/config-%{kernel_unamer}
 /boot/symvers-%{kernel_unamer}.gz
 # Initramfs will be generated after install
-%ghost /boot/initramfs-%{kernel_unamer}%{?dist}
+%ghost /boot/initramfs-%{kernel_unamer}%{?dist}.img
 # Make depmod files ghost files of the core package
 %ghost /lib/modules/%{kernel_unamer}/modules.alias
 %ghost /lib/modules/%{kernel_unamer}/modules.alias.bin

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -1009,6 +1009,7 @@ done
 ###### RPM scriptslets #########################################################
 ### Core package
 # Pre
+%if %{with_core}
 %pre core
 system_arch=$(uname -m)
 if [ %{_target_cpu} != $system_arch ]; then
@@ -1065,6 +1066,7 @@ if [ "$HARDLINK" != "no" -a -x /usr/bin/hardlink -a ! -e /run/ostree-booted ]; t
 		hardlink /usr/src/kernels/*/$f $f > /dev/null
 	done)
 fi
+%endif
 
 ### kernel-tools package
 %if %{with_tools}

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -726,6 +726,8 @@ InstKernelBasic() {
 	%endif
 
 	%ifarch riscv64
+	mkdir dtb
+	cp $_KernBuild/arch/riscv/boot/dts/*/*.dtb dtb/
 	install -m 644 $_KernBuild/arch/riscv/boot/Image vmlinuz
 	%endif
 

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -114,9 +114,6 @@
 %global debuginfo_dir /usr/lib/debug
 
 ###### Build time config #######################################################
-# Currently only x86_64 and aarch64 are supported
-ExclusiveArch: x86_64 aarch64
-
 # Disable kernel building for non-supported arch, allow building userspace package
 %ifarch %nobuildarches noarch
 %global with_core 0
@@ -180,20 +177,17 @@ Source0: %{kernel_tarname}.tar
 ### Build time scripts
 # Script used to assist kernel building
 Source10: filter-modules.sh
-Source12: filter-aarch64.sh
-Source11: filter-x86_64.sh
 
 Source20: module-signer.sh
 Source21: module-keygen.sh
 
 Source30: check-kabi
 
-### Kernel configs and kABI
-# Start from Source1000 to Source1499, for kernel config
-{{CONFSOURCESPEC}}
-
-# Start from Source1500 to Source1999, for kabi
-{{KABISOURCESPEC}}
+### Arch speficied kernel configs and kABI
+# Start from Source1000 to Source1199, for kernel config
+# Start from Source1200 to Source1399, for kabi
+# Start from Source1400 to Source1599, for filter-<arch>.sh
+{{ARCHSOURCESPEC}}
 
 ### Userspace tools
 # Start from Source2000 to Source2999, for userspace tools
@@ -729,13 +723,17 @@ InstKernelBasic() {
 	# NOTE: If we need to sign the vmlinuz, this is the place to do it.
 	%ifarch aarch64
 	install -m 644 $_KernBuild/arch/arm64/boot/Image vmlinuz
-	install -m 644 $_KernBuild/arch/arm64/boot/Image %{buildroot}/boot/vmlinuz-$KernUnameR
+	%endif
+
+	%ifarch riscv64
+	install -m 644 $_KernBuild/arch/riscv/boot/Image vmlinuz
 	%endif
 
 	%ifarch x86_64
 	install -m 644 $_KernBuild/arch/x86/boot/bzImage vmlinuz
-	install -m 644 $_KernBuild/arch/x86/boot/bzImage %{buildroot}/boot/vmlinuz-$KernUnameR
 	%endif
+
+	install -m 644 vmlinuz %{buildroot}/boot/vmlinuz-$KernUnameR
 
 	sha512hmac %{buildroot}/boot/vmlinuz-$KernUnameR | sed -e "s,%{buildroot},," > .vmlinuz.hmac
 	cp .vmlinuz.hmac %{buildroot}/boot/.vmlinuz-$KernUnameR.hmac

--- a/dist/templates/kernel.template.spec
+++ b/dist/templates/kernel.template.spec
@@ -567,7 +567,8 @@ BuildConfig() {
 	sed -i -e "s/^CONFIG_SECURITY_LOCKDOWN_LSM=.*/# CONFIG_SECURITY_LOCKDOWN_LSM is not set/" .config
 	sed -i -e "s/^CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=.*/# CONFIG_SECURITY_LOCKDOWN_LSM_EARLY is not set/" .config
 	%endif
-
+	# Don't use kernel's builtin module compression, imcompatible with debuginfo packaging and signing
+	sed -i -e "s/^\(CONFIG_DECOMPRESS_.*\)=y/# \1 is not set/" .config
 	popd
 }
 


### PR DESCRIPTION
As summary, backport commits from OCKS, fix multiple dist related problem.

Some commits (eg. riscv64 build support) is not working for OCK, but still backport it as it's harmless and keep the code in sync with OCKS.