### PR TITLE
ipv6: fix NULL deref in ip6_rcv_core()

### DIFF
--- a/net/ipv6/ip6_input.c
+++ b/net/ipv6/ip6_input.c
@@ -149,7 +149,7 @@ static struct sk_buff *ip6_rcv_core(struct sk_buff *skb, struct net_device *dev,
 	if ((skb = skb_share_check(skb, GFP_ATOMIC)) == NULL ||
 	    !idev || unlikely(idev->cnf.disable_ipv6)) {
 		__IP6_INC_STATS(net, idev, IPSTATS_MIB_INDISCARDS);
-		if (unlikely(idev->cnf.disable_ipv6))
+		if (idev && unlikely(idev->cnf.disable_ipv6))
 			SKB_DR_SET(reason, IPV6DISABLED);
 		goto drop;
 	}


### PR DESCRIPTION
Upstream commit: 0339d25a2807d913f5645b8d5e485640915f9702
Conflict: None

idev can be NULL, as the surrounding code suggests.

Fixes: 4daf841a2ef3 ("net: ipv6: add skb drop reasons to ip6_rcv_core()")
Signed-off-by: Eric Dumazet <edumazet@google.com>
Cc: Menglong Dong <imagedong@tencent.com>
Cc: Jiang Biao <benbjiang@tencent.com>
Cc: Hao Peng <flyingpeng@tencent.com>
Link: https://lore.kernel.org/r/20220413205653.1178458-1-eric.dumazet@gmail.com
Signed-off-by: Jakub Kicinski <kuba@kernel.org>
Signed-off-by: Kairui Song <kasong@tencent.com>