### PR TITLE
Merge CVE-2021-3760 bugfix patch

### DIFF
--- a/net/nfc/nci/rsp.c
+++ b/net/nfc/nci/rsp.c
@@ -277,6 +277,8 @@ static void nci_core_conn_close_rsp_packet(struct nci_dev *ndev,
 							 ndev->cur_conn_id);
 		if (conn_info) {
 			list_del(&conn_info->list);
+			if (conn_info == ndev->rf_conn_info)
+				ndev->rf_conn_info = NULL;
 			devm_kfree(&ndev->nfc_dev->dev, conn_info);
 		}
 	}


### PR DESCRIPTION
Merge CVE-2021-3760 bugfix patch, and the source of the patch
is as follows:
	1b1499a nfc: nci: fix the UAF of rf_conn_info object